### PR TITLE
file loading, layer system, and ui fixes

### DIFF
--- a/320PhotoEditor/320PhotoEditor.vcxproj
+++ b/320PhotoEditor/320PhotoEditor.vcxproj
@@ -141,7 +141,6 @@
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="ApplicationMenu.cpp" />
-    <ClCompile Include="ComputeShader.cpp" />
     <ClCompile Include="GUI\ColorPickerElement.cpp" />
     <ClCompile Include="Common.cpp" />
     <ClCompile Include="GUI\ButtonElement.cpp" />
@@ -161,11 +160,11 @@
     <ClCompile Include="Tool\ToolManager.cpp" />
     <ClCompile Include="Tool\Tool.cpp" />
     <ClCompile Include="Tool\Zoom.cpp" />
+    <ClCompile Include="WindowListener.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationMenu.h" />
-    <ClInclude Include="ComputeShader.h" />
     <ClInclude Include="GUI\ColorPickerElement.h" />
     <ClInclude Include="GUI\ButtonElement.h" />
     <ClInclude Include="Common.h" />
@@ -184,6 +183,7 @@
     <ClInclude Include="Tool\ToolManager.h" />
     <ClInclude Include="Tool\Tool.h" />
     <ClInclude Include="Tool\Zoom.h" />
+    <ClInclude Include="WindowListener.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/320PhotoEditor/320PhotoEditor.vcxproj
+++ b/320PhotoEditor/320PhotoEditor.vcxproj
@@ -141,6 +141,7 @@
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="ApplicationMenu.cpp" />
+    <ClCompile Include="AssetManager.cpp" />
     <ClCompile Include="ComputeShader.cpp" />
     <ClCompile Include="GUI\ColorPickerElement.cpp" />
     <ClCompile Include="Common.cpp" />
@@ -166,6 +167,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationMenu.h" />
+    <ClInclude Include="AssetManager.h" />
     <ClInclude Include="ComputeShader.h" />
     <ClInclude Include="GUI\ColorPickerElement.h" />
     <ClInclude Include="GUI\ButtonElement.h" />

--- a/320PhotoEditor/320PhotoEditor.vcxproj
+++ b/320PhotoEditor/320PhotoEditor.vcxproj
@@ -141,6 +141,7 @@
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="ApplicationMenu.cpp" />
+    <ClCompile Include="ComputeShader.cpp" />
     <ClCompile Include="GUI\ColorPickerElement.cpp" />
     <ClCompile Include="Common.cpp" />
     <ClCompile Include="GUI\ButtonElement.cpp" />
@@ -164,6 +165,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationMenu.h" />
+    <ClInclude Include="ComputeShader.h" />
     <ClInclude Include="GUI\ColorPickerElement.h" />
     <ClInclude Include="GUI\ButtonElement.h" />
     <ClInclude Include="Common.h" />

--- a/320PhotoEditor/320PhotoEditor.vcxproj
+++ b/320PhotoEditor/320PhotoEditor.vcxproj
@@ -141,6 +141,7 @@
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="ApplicationMenu.cpp" />
+    <ClCompile Include="ComputeShader.cpp" />
     <ClCompile Include="GUI\ColorPickerElement.cpp" />
     <ClCompile Include="Common.cpp" />
     <ClCompile Include="GUI\ButtonElement.cpp" />
@@ -165,6 +166,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="ApplicationMenu.h" />
+    <ClInclude Include="ComputeShader.h" />
     <ClInclude Include="GUI\ColorPickerElement.h" />
     <ClInclude Include="GUI\ButtonElement.h" />
     <ClInclude Include="Common.h" />

--- a/320PhotoEditor/320PhotoEditor.vcxproj.filters
+++ b/320PhotoEditor/320PhotoEditor.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClCompile Include="ComputeShader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="AssetManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h">
@@ -150,6 +153,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ComputeShader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="AssetManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/320PhotoEditor/320PhotoEditor.vcxproj.filters
+++ b/320PhotoEditor/320PhotoEditor.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="WindowListener.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ComputeShader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h">
@@ -144,6 +147,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="WindowListener.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ComputeShader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/320PhotoEditor/320PhotoEditor.vcxproj.filters
+++ b/320PhotoEditor/320PhotoEditor.vcxproj.filters
@@ -78,7 +78,7 @@
     <ClCompile Include="Tool\FilterTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ComputeShader.cpp">
+    <ClCompile Include="WindowListener.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -143,7 +143,7 @@
     <ClInclude Include="Tool\FilterTool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="ComputeShader.h">
+    <ClInclude Include="WindowListener.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/320PhotoEditor/320PhotoEditor.vcxproj.filters
+++ b/320PhotoEditor/320PhotoEditor.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="Tool\FilterTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ComputeShader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h">
@@ -138,6 +141,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Tool\FilterTool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ComputeShader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -36,7 +36,7 @@ bool Application::init(std::string windowName)
 
     toolManager = new ToolManager(window);
     
-    layerManager = new LayerManager(window, { 800, 600 });
+    layerManager = new LayerManager(window, toolManager, { 800, 600 });
     layerManager->createLayer(sf::Color::White);
     
     toolManager->setSelectedLayer(layerManager->getSelectedLayer());

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -50,7 +50,7 @@ bool Application::init(std::string windowName)
     
     toolManager->setSelectedLayer(layerManager->getSelectedLayer());
 
-    applicationMenu = new ApplicationMenu(window, layerManager);
+    applicationMenu = new ApplicationMenu(window, layerManager, toolManager);
 
     toolManager->setApplicationMenu(applicationMenu);
 

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -64,6 +64,7 @@ bool Application::init(std::string windowName)
     addInputListener(applicationMenu->getMenuContainer());
     addInputListener(applicationMenu->getColorContainer());
     addInputListener(toolManager);
+    addInputListener(layerManager);
 
     addWindowListener(applicationMenu->getMenuContainer());
     addWindowListener(applicationMenu->getColorContainer());

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -83,6 +83,11 @@ void Application::run()
             {
                 window->close();
             }
+            else if (event.type == sf::Event::Resized)
+            {
+                sf::FloatRect visibleArea(0, 0, event.size.width, event.size.height);
+                window->setView(sf::View(visibleArea));
+            }
 
             updateWindowListeners(event);
             updateInputListeners(event);

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -170,8 +170,6 @@ void Application::updateWindowListeners(sf::Event event)
     switch (event.type)
     {
     case sf::Event::Resized:
-
-        std::cout << window->getSize().x << std::endl;
         for (const auto& listener : windowListeners)
         {
             listener->windowResize();

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -65,6 +65,10 @@ bool Application::init(std::string windowName)
     addInputListener(applicationMenu->getColorContainer());
     addInputListener(toolManager);
 
+    addWindowListener(applicationMenu->getMenuContainer());
+    addWindowListener(applicationMenu->getColorContainer());
+    addWindowListener(toolManager);
+
     return true;
 }
 
@@ -101,6 +105,16 @@ void Application::addInputListener(InputListener* listener)
 void Application::removeInputListener(InputListener* listener)
 {
     inputListeners.erase(listener);
+}
+
+void Application::addWindowListener(WindowListener* listener)
+{
+    windowListeners.insert(listener);
+}
+
+void Application::removeWindowListener(WindowListener* listener)
+{
+    windowListeners.erase(listener);
 }
 
 void Application::updateInputListeners(sf::Event event)
@@ -151,6 +165,8 @@ void Application::updateWindowListeners(sf::Event event)
     switch (event.type)
     {
     case sf::Event::Resized:
+
+        std::cout << window->getSize().x << std::endl;
         for (const auto& listener : windowListeners)
         {
             listener->windowResize();

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -22,26 +22,17 @@ bool Application::init(std::string windowName)
     //TODO: clean this up, maybe have some sort of asset manager
     window->setKeyRepeatEnabled(false);
 
-    sf::Texture* upTexture = new sf::Texture();
-    upTexture->loadFromFile("../assets/button_up.png");
-    sf::Texture* downTexture = new sf::Texture();
-    downTexture->loadFromFile("../assets/button_down.png");
-    sf::Texture* overTexture = new sf::Texture();
-    overTexture->loadFromFile("../assets/button_over.png");
-    
-    sf::Texture* mosUpTexture = new sf::Texture();
-    mosUpTexture->loadFromFile("../assets/mos_button_up.png");
-    sf::Texture* mosDownTexture = new sf::Texture();
-    mosDownTexture->loadFromFile("../assets/mos_button_down.png");
-    sf::Texture* mosOverTexture = new sf::Texture();
-    mosOverTexture->loadFromFile("../assets/mos_button_over.png");
+    sf::Texture* upTexture = AssetManager::getInstance().getTexture("../assets/button_up.png");
+    sf::Texture* downTexture = AssetManager::getInstance().getTexture("../assets/button_down.png");
+    sf::Texture* overTexture = AssetManager::getInstance().getTexture("../assets/button_over.png");
 
-    sf::Texture* paintupTexture = new sf::Texture();
-    paintupTexture->loadFromFile("../assets/paint_button_up.png");
-    sf::Texture* paintdownTexture = new sf::Texture();
-    paintdownTexture->loadFromFile("../assets/paint_button_down.png");
-    sf::Texture* paintoverTexture = new sf::Texture();
-    paintoverTexture->loadFromFile("../assets/paint_button_over.png");
+    sf::Texture* paintupTexture = AssetManager::getInstance().getTexture("../assets/paint_button_up.png");
+    sf::Texture* paintdownTexture = AssetManager::getInstance().getTexture("../assets/paint_button_down.png");
+    sf::Texture* paintoverTexture = AssetManager::getInstance().getTexture("../assets/paint_button_over.png");
+
+    sf::Texture* mosUpTexture = AssetManager::getInstance().getTexture("../assets/mos_button_up.png");
+    sf::Texture* mosDownTexture = AssetManager::getInstance().getTexture("../assets/mos_button_down.png");
+    sf::Texture* mosOverTexture = AssetManager::getInstance().getTexture("../assets/mos_button_over.png");
 
     toolManager = new ToolManager(window);
     

--- a/320PhotoEditor/Application.cpp
+++ b/320PhotoEditor/Application.cpp
@@ -7,7 +7,7 @@ Application::Application()
 Application::~Application()
 {
     delete toolManager;
-	  delete window;
+	delete window;
 }
 
 bool Application::init(std::string windowName)
@@ -76,8 +76,11 @@ void Application::run()
         while (window->pollEvent(event))
         {
             if (event.type == sf::Event::Closed)
+            {
                 window->close();
+            }
 
+            updateWindowListeners(event);
             updateInputListeners(event);
         }
         window->clear();
@@ -138,6 +141,19 @@ void Application::updateInputListeners(sf::Event event)
         for (const auto& listener : inputListeners)
         {
             listener->mouseMoved(sf::Vector2i(event.mouseMove.x, event.mouseMove.y));
+        }
+        break;
+    }
+}
+
+void Application::updateWindowListeners(sf::Event event)
+{
+    switch (event.type)
+    {
+    case sf::Event::Resized:
+        for (const auto& listener : windowListeners)
+        {
+            listener->windowResize();
         }
         break;
     }

--- a/320PhotoEditor/Application.h
+++ b/320PhotoEditor/Application.h
@@ -14,6 +14,7 @@
 #include "Tool/Zoom.h"
 #include "Layer/LayerManager.h"
 #include "ApplicationMenu.h"
+#include "AssetManager.h"
 
 class Application
 {

--- a/320PhotoEditor/Application.h
+++ b/320PhotoEditor/Application.h
@@ -2,6 +2,7 @@
 
 #include "Common.h"
 #include "InputListener.h"
+#include "WindowListener.h"
 #include "GUI/GUIContainer.h"
 #include "GUI/ButtonElement.h"
 #include "Tool/TestTool.h"
@@ -32,6 +33,7 @@ public:
 private:
 
 	void updateInputListeners(sf::Event event);
+	void updateWindowListeners(sf::Event event);
 
 	sf::RenderWindow* window;
 
@@ -40,4 +42,5 @@ private:
 	ApplicationMenu* applicationMenu;
 
 	std::set<InputListener*> inputListeners;
+	std::set<WindowListener*> windowListeners;
 };

--- a/320PhotoEditor/Application.h
+++ b/320PhotoEditor/Application.h
@@ -30,6 +30,9 @@ public:
 	void addInputListener(InputListener* listener);
 	void removeInputListener(InputListener* listener);
 
+	void addWindowListener(WindowListener* listener);
+	void removeWindowListener(WindowListener* listener);
+
 private:
 
 	void updateInputListeners(sf::Event event);

--- a/320PhotoEditor/ApplicationMenu.cpp
+++ b/320PhotoEditor/ApplicationMenu.cpp
@@ -10,12 +10,9 @@ ApplicationMenu::ApplicationMenu(sf::RenderWindow* renderWindow, LayerManager* l
 	menuContainer = new GUIContainer({ 0, 0 }, { 1, 0.025 }, renderWindow);
 	colorContainer = new GUIContainer({ 0, 0.325 }, { 0.2, 0.4 }, renderWindow);
 
-	sf::Texture* upTexture = new sf::Texture();
-	upTexture->loadFromFile("../assets/button_up.png");
-	sf::Texture* downTexture = new sf::Texture();
-	downTexture->loadFromFile("../assets/button_down.png");
-	sf::Texture* overTexture = new sf::Texture();
-	overTexture->loadFromFile("../assets/button_over.png");
+	sf::Texture* upTexture = AssetManager::getInstance().getTexture("../assets/button_up.png");
+	sf::Texture* downTexture = AssetManager::getInstance().getTexture("../assets/button_down.png");
+	sf::Texture* overTexture = AssetManager::getInstance().getTexture("../assets/button_over.png");
 
 	fileMenuButton = new ButtonElement(upTexture, downTexture, overTexture);
 	fileMenuButton->setUpdateFunction([this](GUIElement* element, int status) { this->buttonPressed(element, status); });

--- a/320PhotoEditor/ApplicationMenu.cpp
+++ b/320PhotoEditor/ApplicationMenu.cpp
@@ -78,13 +78,10 @@ void ApplicationMenu::buttonPressed(GUIElement* button, int status)
 		return;
 	}
 
-
-	//TODO: add some sort of open file dialog
-	//for now just type in the file path
-	std::string filename = "C:\\Users\\Conso\\Pictures\\testimage.png";
-
 	if (button == fileMenuButton)
 	{
+		std::string filename = openFileDialog(renderWindow);
+
 		//check if file exists before attempting load
 		std::ifstream test(filename);
 		if (!test)

--- a/320PhotoEditor/ApplicationMenu.cpp
+++ b/320PhotoEditor/ApplicationMenu.cpp
@@ -1,9 +1,11 @@
 #include "ApplicationMenu.h"
+#include "Tool/ToolManager.h"
 
-ApplicationMenu::ApplicationMenu(sf::RenderWindow* renderWindow, LayerManager* layerManager)
+ApplicationMenu::ApplicationMenu(sf::RenderWindow* renderWindow, LayerManager* layerManager, ToolManager* toolManager)
 {
 	this->renderWindow = renderWindow;
 	this->layerManager = layerManager;
+	this->toolManager = toolManager;
 
 	menuContainer = new GUIContainer({ 0, 0 }, { 1, 0.025 }, renderWindow);
 	colorContainer = new GUIContainer({ 0, 0.325 }, { 0.2, 0.4 }, renderWindow);
@@ -91,8 +93,10 @@ void ApplicationMenu::buttonPressed(GUIElement* button, int status)
 		}
 		test.close();
 
-		layerManager->getSelectedLayer()->getImage()->loadFromFile(filename);
-		layerManager->getSelectedLayer()->reload();
+		//layerManager->removeSelectedLayer();
+		layerManager->createLayerFromFile(filename);
+		toolManager->setSelectedLayer(layerManager->getSelectedLayer());
+		toolManager->restartTool();
 	}
 	else if (button == incrLightness)
 	{

--- a/320PhotoEditor/ApplicationMenu.cpp
+++ b/320PhotoEditor/ApplicationMenu.cpp
@@ -2,6 +2,7 @@
 
 ApplicationMenu::ApplicationMenu(sf::RenderWindow* renderWindow, LayerManager* layerManager)
 {
+	this->renderWindow = renderWindow;
 	this->layerManager = layerManager;
 
 	menuContainer = new GUIContainer({ 0, 0 }, { 1, 0.025 }, renderWindow);

--- a/320PhotoEditor/ApplicationMenu.h
+++ b/320PhotoEditor/ApplicationMenu.h
@@ -28,6 +28,8 @@ private:
 
 	LayerManager* layerManager;
 
+	sf::RenderWindow* renderWindow;
+
 	GUIContainer* menuContainer;
 	GUIContainer* colorContainer;
 	ButtonElement* fileMenuButton;

--- a/320PhotoEditor/ApplicationMenu.h
+++ b/320PhotoEditor/ApplicationMenu.h
@@ -3,15 +3,17 @@
 #include "GUI/GUIContainer.h"
 #include "GUI/ButtonElement.h"
 #include "GUI/ColorPickerElement.h"
-#include "Layer/LayerManager.h"1
+#include "Layer/LayerManager.h"
 
 #include <fstream>
+
+class ToolManager;
 
 class ApplicationMenu
 {
 public:
 
-	ApplicationMenu(sf::RenderWindow* renderWindow, LayerManager* toolManager);
+	ApplicationMenu(sf::RenderWindow* renderWindow, LayerManager* layerManager, ToolManager* toolManager);
 	~ApplicationMenu();
 
 	void update();
@@ -27,6 +29,7 @@ private:
 	void buttonPressed(GUIElement* button, int status);
 
 	LayerManager* layerManager;
+	ToolManager* toolManager;
 
 	sf::RenderWindow* renderWindow;
 

--- a/320PhotoEditor/ApplicationMenu.h
+++ b/320PhotoEditor/ApplicationMenu.h
@@ -4,6 +4,7 @@
 #include "GUI/ButtonElement.h"
 #include "GUI/ColorPickerElement.h"
 #include "Layer/LayerManager.h"
+#include "AssetManager.h"
 
 #include <fstream>
 

--- a/320PhotoEditor/AssetManager.cpp
+++ b/320PhotoEditor/AssetManager.cpp
@@ -1,0 +1,17 @@
+#include "AssetManager.h"
+
+sf::Texture* AssetManager::getTexture(std::string name)
+{
+	auto search = textures.find(name);
+	if(search != textures.end())
+	{
+		return search->second;
+	}
+	else
+	{
+		sf::Texture* texture = new sf::Texture();
+		texture->loadFromFile(name);
+		textures.insert(std::make_pair(name, texture));
+		return texture;
+	}
+}

--- a/320PhotoEditor/AssetManager.h
+++ b/320PhotoEditor/AssetManager.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "Common.h"
+
+class AssetManager
+{
+public:
+	static AssetManager& getInstance()
+	{
+		static AssetManager instance;
+		return instance;
+	}
+	
+	sf::Texture* getTexture(std::string name);
+
+private:
+	AssetManager() {};
+
+	std::map<std::string, sf::Texture*> textures;
+};
+

--- a/320PhotoEditor/Common.cpp
+++ b/320PhotoEditor/Common.cpp
@@ -87,3 +87,47 @@ sf::Color hsl2rgb(float h, float s, float l)
 
 	return rgb;
 }
+
+#ifdef _WIN32
+	#include <Windows.h>
+	#include <tchar.h>
+	#include <atlstr.h>
+	std::string openFileDialog(sf::RenderWindow* parentWindow)
+	{
+		OPENFILENAME ofn;
+		TCHAR szFile[260] = { 0 };
+
+		// Initialize OPENFILENAME
+		ZeroMemory(&ofn, sizeof(ofn));
+		ofn.lStructSize = sizeof(ofn);
+		ofn.hwndOwner = (HWND)parentWindow->getSystemHandle();
+		ofn.lpstrFile = szFile;
+		ofn.nMaxFile = sizeof(szFile);
+		ofn.lpstrFilter = _T("All\0*.*\0");
+		ofn.nFilterIndex = 1;
+		ofn.lpstrFileTitle = NULL;
+		ofn.nMaxFileTitle = 0;
+		ofn.lpstrInitialDir = NULL;
+		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+
+		if (GetOpenFileName(&ofn) == TRUE)
+		{
+			return std::string(CW2A(ofn.lpstrFile));
+		}
+
+		std::cerr << "Error: open file dialog fail" << std::endl;
+
+		return "";
+	}
+#elif __APPLE__
+	std::string openFileDialog()
+	{
+		return "";
+	}
+#else
+	std::string openFileDialog()
+	{
+		std::cerr << "Error: Unkown OS, unable to create open file dialog"
+		return "";
+	}
+#endif

--- a/320PhotoEditor/Common.cpp
+++ b/320PhotoEditor/Common.cpp
@@ -97,7 +97,6 @@ sf::Color hsl2rgb(float h, float s, float l)
 		OPENFILENAME ofn;
 		TCHAR szFile[260] = { 0 };
 
-		// Initialize OPENFILENAME
 		ZeroMemory(&ofn, sizeof(ofn));
 		ofn.lStructSize = sizeof(ofn);
 		ofn.hwndOwner = (HWND)parentWindow->getSystemHandle();

--- a/320PhotoEditor/Common.cpp
+++ b/320PhotoEditor/Common.cpp
@@ -121,7 +121,9 @@ sf::Color hsl2rgb(float h, float s, float l)
 #elif __APPLE__
 	std::string openFileDialog()
 	{
-		return "";
+		std::string path;
+		std::cin >> path;
+		return path;
 	}
 #else
 	std::string openFileDialog()

--- a/320PhotoEditor/Common.h
+++ b/320PhotoEditor/Common.h
@@ -28,3 +28,5 @@ float hue2rgb(float p, float q, float t);
 
 //h s l range [0,1]
 sf::Color hsl2rgb(float h, float s, float l);
+
+std::string openFileDialog(sf::RenderWindow* parentWindow);

--- a/320PhotoEditor/ComputeShader.cpp
+++ b/320PhotoEditor/ComputeShader.cpp
@@ -1,0 +1,35 @@
+#include "ComputeShader.h"
+
+ComputeShader::ComputeShader(const char* path)
+{
+	compile(path);
+}
+
+void ComputeShader::use()
+{
+}
+
+void ComputeShader::compile(const char* path)
+{
+	std::ifstream shaderFile;
+	shaderFile.open(path);
+
+	if (!shaderFile.is_open())
+	{
+		std::cerr << "Error: unable to open shader file: " << path << std::endl;
+	}
+
+	std::stringstream shaderStream;
+	shaderStream << shaderFile.rdbuf();
+
+	shaderFile.close();
+
+	std::string sshaderCode = shaderStream.str();
+	const char* shaderCode = sshaderCode.c_str();
+
+
+}
+
+void ComputeShader::checkCompileErrors()
+{
+}

--- a/320PhotoEditor/ComputeShader.h
+++ b/320PhotoEditor/ComputeShader.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Common.h"
+#include <fstream>
+#include <sstream>
+
+class ComputeShader
+{
+public:
+
+	ComputeShader(const char* path);
+
+	void use();
+
+private:
+
+	void compile(const char* path);
+
+	void checkCompileErrors();
+};
+

--- a/320PhotoEditor/GUI/ButtonElement.cpp
+++ b/320PhotoEditor/GUI/ButtonElement.cpp
@@ -2,7 +2,7 @@
 
 //TODO: fix issues where texture not updating
 
-ButtonElement::ButtonElement(sf::Texture* up, sf::Texture* down, sf::Texture* over) :  up(up), down(down), over(over)
+ButtonElement::ButtonElement(sf::Texture* up, sf::Texture* down, sf::Texture* over, bool toggle) :  up(up), down(down), over(over)
 {
 	sprite = new sf::Sprite(*up);
 
@@ -10,21 +10,46 @@ ButtonElement::ButtonElement(sf::Texture* up, sf::Texture* down, sf::Texture* ov
 	setVisible(true);
 
 	buttonState = UP;
+
+	this->toggle = toggle;
 }
 
 void ButtonElement::mousePressed(sf::Mouse::Button button)
 {
 	if (isCursorOver(cursorPos))
 	{
-		sprite->setTexture(*down);
-		buttonState = DOWN;
+		if (toggle)
+		{
+			if (buttonState == DOWN)
+			{
+				sprite->setTexture(*up);
+				buttonState = UP;
+				updateFunc(this, UP);
+			}
+			else
+			{
+				sprite->setTexture(*down);
+				buttonState = DOWN;
+				updateFunc(this, DOWN);
+			}
+		}
+		else
+		{
+			sprite->setTexture(*down);
+			buttonState = DOWN;
 
-		updateFunc(this, DOWN);
+			updateFunc(this, DOWN);
+		}
 	}
 }
 
 void ButtonElement::mouseReleased(sf::Mouse::Button button)
 {
+	if (toggle)
+	{
+		return;
+	}
+
 	if (buttonState == DOWN)
 	{
 		if (isCursorOver(cursorPos))
@@ -47,6 +72,11 @@ void ButtonElement::mouseReleased(sf::Mouse::Button button)
 void ButtonElement::mouseMoved(sf::Vector2i pos)
 {
 	cursorPos = pos;
+	if (toggle)
+	{
+		return;
+	}
+
 	if (isCursorOver(cursorPos) && buttonState != DOWN)
 	{
 		sprite->setTexture(*over);

--- a/320PhotoEditor/GUI/ButtonElement.h
+++ b/320PhotoEditor/GUI/ButtonElement.h
@@ -14,7 +14,9 @@ public:
 		OVER
 	} ButtonState;
 
-	ButtonElement(sf::Texture* up, sf::Texture* down, sf::Texture* over);
+	//when toggle is true, buttons toggle instead of being pressed once
+	//over texture is not used when toggle is set to true
+	ButtonElement(sf::Texture* up, sf::Texture* down, sf::Texture* over, bool toggle = false);
 
 	void mousePressed(sf::Mouse::Button button);
 	void mouseReleased(sf::Mouse::Button button);
@@ -36,5 +38,7 @@ private:
 	sf::Sprite* sprite;
 
     ButtonState buttonState;
+
+	bool toggle;
 };
 

--- a/320PhotoEditor/GUI/GUIContainer.cpp
+++ b/320PhotoEditor/GUI/GUIContainer.cpp
@@ -17,6 +17,7 @@ sf::Vector2f GUIContainer::getPosition()
 
 void GUIContainer::setPosition(sf::Vector2f pos)
 {
+    rawPos = pos;
     if (rightAnchor)
     {
         float aspect = (float)renderWindow->getSize().x / (float)renderWindow->getSize().y;
@@ -107,6 +108,15 @@ void GUIContainer::mouseMoved(sf::Vector2i pos)
     for (const auto& element : elements)
     {
         element->mouseMoved(pos);
+    }
+}
+
+void GUIContainer::windowResize()
+{
+    setPosition(rawPos);
+    for (GUIElement* element : elements)
+    {
+        element->rebuild();
     }
 }
 

--- a/320PhotoEditor/GUI/GUIContainer.h
+++ b/320PhotoEditor/GUI/GUIContainer.h
@@ -2,12 +2,13 @@
 
 #include "../Common.h"
 #include "../InputListener.h"
+#include "../WindowListener.h"
 #include "GUIElement.h"
 
 class GUIElement;
 
 //an invisible container for GUIElements
-class GUIContainer : public InputListener
+class GUIContainer : public InputListener, public WindowListener
 {
 public:
 
@@ -34,6 +35,8 @@ public:
 	void mouseReleased(sf::Mouse::Button button);
 	void mouseMoved(sf::Vector2i pos);
 
+	void windowResize();
+
 private:
 
 	bool isCursorOver(sf::Vector2i cursorPos);
@@ -44,6 +47,7 @@ private:
 	bool visible;
 
 	sf::Vector2f pos;
+	sf::Vector2f rawPos;
 	sf::Vector2f size;
 
 	std::set<GUIElement*> elements;

--- a/320PhotoEditor/GUI/GUIElement.cpp
+++ b/320PhotoEditor/GUI/GUIElement.cpp
@@ -13,6 +13,12 @@ void GUIElement::setVisible(bool visible)
 	this->visible = visible;
 }
 
+void GUIElement::rebuild()
+{
+	setSize(size);
+	setPosition(pos);
+}
+
 void GUIElement::setContainer(GUIContainer* container)
 {
 	this->container = container;

--- a/320PhotoEditor/GUI/GUIElement.h
+++ b/320PhotoEditor/GUI/GUIElement.h
@@ -25,6 +25,9 @@ public:
 	//set position relative to parent gui
 	virtual void setPosition(sf::Vector2f pos) = 0;
 
+	//rebuilds the element by resetting the size and position
+	void rebuild();
+
 	void setContainer(GUIContainer* container);
 
 	bool isCursorOver(sf::Vector2i cursorPos);

--- a/320PhotoEditor/Layer/Layer.cpp
+++ b/320PhotoEditor/Layer/Layer.cpp
@@ -18,6 +18,24 @@ Layer::Layer(sf::Vector2u size, sf::Color color, sf::RenderWindow* renderWindow)
 	this->renderWindow = renderWindow;
 }
 
+Layer::Layer(std::string filePath, sf::RenderWindow* renderWindow)
+{
+	image = new sf::Image();
+	image->loadFromFile(filePath);
+
+	mask = new sf::Image();
+	mask->create(image->getSize().x, image->getSize().y, sf::Color::White);
+
+	texture = sf::Texture();
+	texture.loadFromImage(*image);
+
+	sprite = new sf::Sprite(texture);
+
+	visible = true;
+
+	this->renderWindow = renderWindow;
+}
+
 sf::Image* Layer::getImage()
 {
 	return image;

--- a/320PhotoEditor/Layer/Layer.cpp
+++ b/320PhotoEditor/Layer/Layer.cpp
@@ -54,7 +54,7 @@ sf::Sprite* Layer::getSprite()
 sf::Vector2i Layer::cursorToPixel(sf::Vector2i cursorPos)
 {
 	//TODO: make adjust for image scale and position
-	return sf::Vector2i(cursorPos.x - sprite->getPosition().x, cursorPos.y - sprite->getPosition().y);
+	return sf::Vector2i(cursorPos.x - sprite->getPosition().x + sprite->getOrigin().x, cursorPos.y - sprite->getPosition().y + sprite->getOrigin().y);
 }
 
 bool Layer::isCursorOver(sf::Vector2i cursorPos)
@@ -62,11 +62,11 @@ bool Layer::isCursorOver(sf::Vector2i cursorPos)
 	sf::Vector2u windowSize = renderWindow->getSize();
 	sf::Vector2f spritePos = sprite->getPosition();
 
-	float left = spritePos.x;
-	float right = spritePos.x + sprite->getTexture()->getSize().x;
-	float top = spritePos.y;
+	float left = spritePos.x - sprite->getOrigin().x;
+	float right = spritePos.x + sprite->getTexture()->getSize().x - sprite->getOrigin().x;
+	float top = spritePos.y - sprite->getOrigin().y;
 	//TODO: last pixel on y axis doesnt want to be written to for some reason
-	float bottom = spritePos.y + sprite->getTexture()->getSize().y - 1;
+	float bottom = spritePos.y + sprite->getTexture()->getSize().y - sprite->getOrigin().y - 1;
 
 	return cursorPos.x >= left && cursorPos.x <= right && cursorPos.y >= top && cursorPos.y <= bottom;
 }

--- a/320PhotoEditor/Layer/Layer.cpp
+++ b/320PhotoEditor/Layer/Layer.cpp
@@ -1,27 +1,24 @@
 #include "Layer.h"
 
 Layer::Layer(sf::Vector2u size, sf::Color color, sf::RenderWindow* renderWindow)
-{
-	image = new sf::Image();
+{	
+	sf::Image* image = new sf::Image();
 	image->create(size.x, size.y, color);
-	
-	mask = new sf::Image();
-	mask->create(size.x, size.y, sf::Color::White);
 
-	texture = sf::Texture();
-	texture.loadFromImage(*image);
-
-	sprite = new sf::Sprite(texture);
-
-	visible = true;
-
-	this->renderWindow = renderWindow;
+	createLayer(image, renderWindow);
 }
 
 Layer::Layer(std::string filePath, sf::RenderWindow* renderWindow)
 {
-	image = new sf::Image();
+	sf::Image* image = new sf::Image();
 	image->loadFromFile(filePath);
+
+	createLayer(image, renderWindow);
+}
+
+void Layer::createLayer(sf::Image* image, sf::RenderWindow* renderWindow)
+{
+	this->image = image;
 
 	mask = new sf::Image();
 	mask->create(image->getSize().x, image->getSize().y, sf::Color::White);

--- a/320PhotoEditor/Layer/Layer.h
+++ b/320PhotoEditor/Layer/Layer.h
@@ -9,6 +9,7 @@ class Layer
 public:
 
 	Layer(sf::Vector2u size, sf::Color color, sf::RenderWindow* renderWindow);
+	Layer(std::string filePath, sf::RenderWindow* renderWindow);
 
 	//actual image data
 	sf::Image* getImage();

--- a/320PhotoEditor/Layer/Layer.h
+++ b/320PhotoEditor/Layer/Layer.h
@@ -7,7 +7,6 @@
 class Layer
 {
 public:
-
 	Layer(sf::Vector2u size, sf::Color color, sf::RenderWindow* renderWindow);
 	Layer(std::string filePath, sf::RenderWindow* renderWindow);
 
@@ -29,6 +28,8 @@ public:
 	~Layer();
 
 private:
+
+	void createLayer(sf::Image* image, sf::RenderWindow* renderWindow);
 
 	sf::RenderWindow* renderWindow;
 

--- a/320PhotoEditor/Layer/LayerManager.cpp
+++ b/320PhotoEditor/Layer/LayerManager.cpp
@@ -1,22 +1,22 @@
 #include "LayerManager.h"
 
-LayerManager::LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u projectImageSize)
+LayerManager::LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u defaultImageSize)
 {
 	this->renderWindow = renderWindow;
-	this->projectImageSize = projectImageSize;
+	this->defaultImageSize = defaultImageSize;
 
 	selectionContainer = new GUIContainer({0, 0.25 }, {.2, .75}, renderWindow, true);
 }
 
 void LayerManager::createLayer(sf::Color color)
 {
-	Layer* layer = new Layer(projectImageSize, color, renderWindow);
+	Layer* layer = new Layer(defaultImageSize, color, renderWindow);
 	
 	ButtonElement* button = createLayerButton(layer->getImage());
 
 	sf::Sprite* sprite = layer->getSprite();
 
-	sf::Vector2u imageCenter = projectImageSize / 2;
+	sf::Vector2u imageCenter = defaultImageSize / 2;
 	sf::Vector2u screenCenter = renderWindow->getSize() / 2;
 
 	sf::Vector2f offset(screenCenter.x, screenCenter.y);
@@ -42,11 +42,12 @@ void LayerManager::createLayerFromFile(std::string filePath)
 
 	sf::Sprite* sprite = layer->getSprite();
 
-	sf::Vector2u imageCenter = projectImageSize / 2;
+	sf::Vector2u imageCenter = layer->getImage()->getSize() / 2;
 	sf::Vector2u screenCenter = renderWindow->getSize() / 2;
 
-	sf::Vector2f offset(screenCenter.x - imageCenter.x, screenCenter.y - imageCenter.y);
+	sf::Vector2f offset(screenCenter.x, screenCenter.y);
 
+	sprite->setOrigin({ (float)imageCenter.x, (float)imageCenter.y });
 	sprite->setPosition(offset);
 
 	layers.push_back(std::make_pair(layer, button));
@@ -57,8 +58,9 @@ void LayerManager::removeSelectedLayer()
 {
 	selectionContainer->removeElement(layers.at(selectedLayer).second);
 	delete layers.at(selectedLayer).second;
-	layers.erase(layers.begin() + selectedLayer);
 	delete layers.at(selectedLayer).first;
+	layers.erase(layers.begin() + selectedLayer);
+	selectedLayer--;
 }
 
 Layer* LayerManager::getSelectedLayer()
@@ -82,8 +84,26 @@ ButtonElement* LayerManager::createLayerButton(sf::Image* img)
 	tex->loadFromImage(*img);
 	ButtonElement* button = new ButtonElement(tex, tex, tex);
 	selectionContainer->addElement(button);
-	button->setPosition({ 0,0 });
+	button->setPosition({ 0, 1 - (layers.size() * 0.08f) - 0.1f });
 	button->setSize({ 0.3, 0.075 });
 
 	return button;
+}
+
+void LayerManager::buttonPressed(GUIElement* button, int status)
+{
+	if (status != ButtonElement::ButtonState::DOWN)
+	{
+		return;
+	}
+
+	int i = 0;
+	for (auto layer : layers)
+	{
+		if (layer.second == button)
+		{
+			selectedLayer = i;
+		}
+		i++;
+	}
 }

--- a/320PhotoEditor/Layer/LayerManager.cpp
+++ b/320PhotoEditor/Layer/LayerManager.cpp
@@ -1,8 +1,10 @@
 #include "LayerManager.h"
+#include "../Tool/ToolManager.h"
 
-LayerManager::LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u defaultImageSize)
+LayerManager::LayerManager(sf::RenderWindow* renderWindow, ToolManager* toolManager, sf::Vector2u defaultImageSize)
 {
 	this->renderWindow = renderWindow;
+	this->toolManager = toolManager;
 	this->defaultImageSize = defaultImageSize;
 
 	selectionContainer = new GUIContainer({0, 0.25 }, {.2, .75}, renderWindow, true);
@@ -117,9 +119,11 @@ void LayerManager::buttonPressed(GUIElement* button, int status)
 	int i = 0;
 	for (LayerData layer : layers)
 	{
-		if (std::get<2>(layer) == button  && status != ButtonElement::ButtonState::DOWN)
+		if (std::get<2>(layer) == button && status != ButtonElement::ButtonState::DOWN)
 		{
 			selectedLayer = i;
+			toolManager->setSelectedLayer(getSelectedLayer());
+			toolManager->restartTool();
 			break;
 		}
 		else if (std::get<3>(layer) == button)

--- a/320PhotoEditor/Layer/LayerManager.cpp
+++ b/320PhotoEditor/Layer/LayerManager.cpp
@@ -100,10 +100,8 @@ ButtonElement* LayerManager::createLayerButton(sf::Image* img)
 
 ButtonElement* LayerManager::createVisButton()
 {
-	sf::Texture* upTexture = new sf::Texture();
-	upTexture->loadFromFile("../assets/button_up.png");
-	sf::Texture* downTexture = new sf::Texture();
-	downTexture->loadFromFile("../assets/button_down.png");
+	sf::Texture* upTexture = AssetManager::getInstance().getTexture("../assets/button_up.png");
+	sf::Texture* downTexture = AssetManager::getInstance().getTexture("../assets/button_down.png");
 
 	ButtonElement* button = new ButtonElement(upTexture, downTexture, nullptr, true);
 	selectionContainer->addElement(button);

--- a/320PhotoEditor/Layer/LayerManager.cpp
+++ b/320PhotoEditor/Layer/LayerManager.cpp
@@ -19,8 +19,9 @@ void LayerManager::createLayer(sf::Color color)
 	sf::Vector2u imageCenter = projectImageSize / 2;
 	sf::Vector2u screenCenter = renderWindow->getSize() / 2;
 
-	sf::Vector2f offset(screenCenter.x - imageCenter.x, screenCenter.y - imageCenter.y);
+	sf::Vector2f offset(screenCenter.x, screenCenter.y);
 
+	sprite->setOrigin({ (float)imageCenter.x, (float)imageCenter.y });
 	sprite->setPosition(offset);
 
 	layers.push_back(std::make_pair(layer, button));

--- a/320PhotoEditor/Layer/LayerManager.cpp
+++ b/320PhotoEditor/Layer/LayerManager.cpp
@@ -21,6 +21,30 @@ void LayerManager::createLayer(sf::Color color)
 	layers.insert(selectedLayer);
 }
 
+void LayerManager::createLayerFromFile(std::string filePath)
+{
+	Layer* layer = new Layer(filePath, renderWindow);
+
+	if (layer->getImage() == nullptr)
+	{
+		delete layer;
+		return;
+	}
+
+	selectedLayer = layer;
+
+	sf::Sprite* sprite = selectedLayer->getSprite();
+
+	sf::Vector2u imageCenter = projectImageSize / 2;
+	sf::Vector2u screenCenter = renderWindow->getSize() / 2;
+
+	sf::Vector2f offset(screenCenter.x - imageCenter.x, screenCenter.y - imageCenter.y);
+
+	sprite->setPosition(offset);
+
+	layers.insert(selectedLayer);
+}
+
 void LayerManager::removeSelectedLayer()
 {
 	layers.erase(selectedLayer);

--- a/320PhotoEditor/Layer/LayerManager.h
+++ b/320PhotoEditor/Layer/LayerManager.h
@@ -6,7 +6,7 @@
 #include "../GUI/ButtonElement.h"
 
 //handles layer selection gui
-class LayerManager
+class LayerManager : public InputListener
 {
 public:
 	LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u defaultImageSize);
@@ -28,14 +28,22 @@ public:
 private:
 
 	ButtonElement* createLayerButton(sf::Image* img);
+	ButtonElement* createVisButton();
 
 	void buttonPressed(GUIElement* button, int status);
+
+	void mousePressed(sf::Mouse::Button button);
+	void mouseReleased(sf::Mouse::Button button);
+	void mouseMoved(sf::Vector2i pos);
 
 	sf::RenderWindow* renderWindow;
 
 	sf::Vector2u defaultImageSize;
 
-	std::vector<std::pair<Layer*, ButtonElement*>> layers;
+	//layer, visiblity then its select button and visiblity button
+	typedef std::tuple<Layer*, bool, ButtonElement*, ButtonElement*> LayerData;
+
+	std::vector<LayerData> layers;
 
 	unsigned int selectedLayer;
 

--- a/320PhotoEditor/Layer/LayerManager.h
+++ b/320PhotoEditor/Layer/LayerManager.h
@@ -3,6 +3,7 @@
 #include "../Common.h"
 #include "../GUI/GUIContainer.h"
 #include "Layer.h"
+#include "../GUI/ButtonElement.h"
 
 //handles layer selection gui
 class LayerManager
@@ -26,11 +27,15 @@ public:
 
 private:
 
+	ButtonElement* createLayerButton(sf::Image* img);
+
 	sf::RenderWindow* renderWindow;
 
 	sf::Vector2u projectImageSize;
 
-	std::set<Layer*> layers;
+	std::vector<std::pair<Layer*, ButtonElement*>> layers;
 
-	Layer* selectedLayer;
+	unsigned int selectedLayer;
+
+	GUIContainer* selectionContainer;
 };

--- a/320PhotoEditor/Layer/LayerManager.h
+++ b/320PhotoEditor/Layer/LayerManager.h
@@ -6,11 +6,13 @@
 #include "../GUI/ButtonElement.h"
 #include "../AssetManager.h"
 
+class ToolManager;
+
 //handles layer selection gui
 class LayerManager : public InputListener
 {
 public:
-	LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u defaultImageSize);
+	LayerManager(sf::RenderWindow* renderWindow, ToolManager* toolManager, sf::Vector2u defaultImageSize);
 
 	//creates a new layer and then selects it
 	void createLayer(sf::Color color);
@@ -38,6 +40,7 @@ private:
 	void mouseMoved(sf::Vector2i pos);
 
 	sf::RenderWindow* renderWindow;
+	ToolManager* toolManager;
 
 	sf::Vector2u defaultImageSize;
 

--- a/320PhotoEditor/Layer/LayerManager.h
+++ b/320PhotoEditor/Layer/LayerManager.h
@@ -4,6 +4,7 @@
 #include "../GUI/GUIContainer.h"
 #include "Layer.h"
 #include "../GUI/ButtonElement.h"
+#include "../AssetManager.h"
 
 //handles layer selection gui
 class LayerManager : public InputListener

--- a/320PhotoEditor/Layer/LayerManager.h
+++ b/320PhotoEditor/Layer/LayerManager.h
@@ -12,6 +12,10 @@ public:
 
 	//creates a new layer and then selects it
 	void createLayer(sf::Color color);
+
+	//also selects when successfully loaded
+	void createLayerFromFile(std::string filePath);
+	
 	//removes the selected layer
 	void removeSelectedLayer();
 

--- a/320PhotoEditor/Layer/LayerManager.h
+++ b/320PhotoEditor/Layer/LayerManager.h
@@ -9,7 +9,7 @@
 class LayerManager
 {
 public:
-	LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u projectImageSize);
+	LayerManager(sf::RenderWindow* renderWindow, sf::Vector2u defaultImageSize);
 
 	//creates a new layer and then selects it
 	void createLayer(sf::Color color);
@@ -29,9 +29,11 @@ private:
 
 	ButtonElement* createLayerButton(sf::Image* img);
 
+	void buttonPressed(GUIElement* button, int status);
+
 	sf::RenderWindow* renderWindow;
 
-	sf::Vector2u projectImageSize;
+	sf::Vector2u defaultImageSize;
 
 	std::vector<std::pair<Layer*, ButtonElement*>> layers;
 

--- a/320PhotoEditor/Tool/PaintTool.cpp
+++ b/320PhotoEditor/Tool/PaintTool.cpp
@@ -9,12 +9,9 @@ PaintTool::PaintTool(sf::Texture* up, sf::Texture* down, sf::Texture* over) : To
 
 void PaintTool::init()
 {
-	sf::Texture* upTexture = new sf::Texture();
-	upTexture->loadFromFile("../assets/button_up.png");
-	sf::Texture* downTexture = new sf::Texture();
-	downTexture->loadFromFile("../assets/button_down.png");
-	sf::Texture* overTexture = new sf::Texture();
-	overTexture->loadFromFile("../assets/button_over.png");
+	sf::Texture* upTexture = AssetManager::getInstance().getTexture("../assets/button_up.png");
+	sf::Texture* downTexture = AssetManager::getInstance().getTexture("../assets/button_down.png");
+	sf::Texture* overTexture = AssetManager::getInstance().getTexture("../assets/button_over.png");
 
 	incrSizeButton = new ButtonElement(upTexture, downTexture, overTexture);
 	incrSizeButton->setUpdateFunction([this](GUIElement* element, int status) { this->buttonPressed(element, status); });

--- a/320PhotoEditor/Tool/PaintTool.h
+++ b/320PhotoEditor/Tool/PaintTool.h
@@ -2,6 +2,7 @@
 
 #include "Tool.h"
 #include "../GUI/ButtonElement.h"
+#include "../AssetManager.h"
 
 class PaintTool : public Tool
 {

--- a/320PhotoEditor/Tool/SelectTool.cpp
+++ b/320PhotoEditor/Tool/SelectTool.cpp
@@ -7,12 +7,9 @@ SelectTool::SelectTool(sf::Texture* up, sf::Texture* down, sf::Texture* over) : 
 
 void SelectTool::init()
 {
-	sf::Texture* upTexture = new sf::Texture();
-	upTexture->loadFromFile("../assets/button_up.png");
-	sf::Texture* downTexture = new sf::Texture();
-	downTexture->loadFromFile("../assets/button_down.png");
-	sf::Texture* overTexture = new sf::Texture();
-	overTexture->loadFromFile("../assets/button_over.png");
+	sf::Texture* upTexture = AssetManager::getInstance().getTexture("../assets/button_up.png");
+	sf::Texture* downTexture = AssetManager::getInstance().getTexture("../assets/button_down.png");
+	sf::Texture* overTexture = AssetManager::getInstance().getTexture("../assets/button_over.png");
 
 	boxSelectButton = new ButtonElement(upTexture, downTexture, overTexture);
 	boxSelectButton->setUpdateFunction([this](GUIElement* element, int status) { this->buttonPressed(element, status); });

--- a/320PhotoEditor/Tool/SelectTool.h
+++ b/320PhotoEditor/Tool/SelectTool.h
@@ -2,6 +2,7 @@
 
 #include "Tool.h"
 #include "../GUI/ButtonElement.h"
+#include "../AssetManager.h"
 
 class SelectTool : public Tool
 {

--- a/320PhotoEditor/Tool/ToolManager.cpp
+++ b/320PhotoEditor/Tool/ToolManager.cpp
@@ -134,6 +134,11 @@ void ToolManager::mouseMoved(sf::Vector2i pos)
 	toolSelector->mouseMoved(pos);
 }
 
+void ToolManager::windowResize()
+{
+	toolSelector->windowResize();
+}
+
 void ToolManager::buttonPressed(GUIElement* button, int status)
 {
 	if (status == ButtonElement::DOWN)

--- a/320PhotoEditor/Tool/ToolManager.h
+++ b/320PhotoEditor/Tool/ToolManager.h
@@ -6,12 +6,13 @@
 #include "../GUI/ButtonElement.h"
 #include "../GUI/PanelElement.h"
 #include "../InputListener.h"
+#include "../WindowListener.h"
 #include "../Layer/Layer.h"
 #include "../ApplicationMenu.h"
 
 #define PANEL_ROWS 4
 
-class ToolManager : public InputListener
+class ToolManager : public InputListener, public WindowListener
 {
 public:
 
@@ -39,6 +40,8 @@ private:
 	void mouseReleased(sf::Mouse::Button button);
 	void mouseScrolled(int delta);
 	void mouseMoved(sf::Vector2i pos);
+
+	void windowResize();
 
 	void buttonPressed(GUIElement* button, int status);
 

--- a/320PhotoEditor/WindowListener.cpp
+++ b/320PhotoEditor/WindowListener.cpp
@@ -1,0 +1,1 @@
+#include "WindowListener.h"

--- a/320PhotoEditor/WindowListener.h
+++ b/320PhotoEditor/WindowListener.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Common.h"
+
+class WindowListener
+{
+public:
+
+	virtual void windowResize();
+};

--- a/320PhotoEditor/WindowListener.h
+++ b/320PhotoEditor/WindowListener.h
@@ -6,5 +6,5 @@ class WindowListener
 {
 public:
 
-	virtual void windowResize();
+	virtual void windowResize() {};
 };


### PR DESCRIPTION
Most of the UI now updates properly with window resizes.

On windows, using the load file button creates a new layer with the selected file from the open file dialog.
On mac it does the same but it just gets the file path from console input for now.

Layer system now supports different image sizes, loading from files, and has a layer stack that can be selected and hidden.

There is now a proper asset manager that can grab any asset like normal but doesn't load it again if it has already been loaded.